### PR TITLE
Add ENS endpoint to be used as a reverse registrar

### DIFF
--- a/api/handlers.go
+++ b/api/handlers.go
@@ -270,6 +270,10 @@ func HandleAddress(w http.ResponseWriter, r *http.Request) {
 		BlockRewards: blockRewards,
 	}
 
+	if addressEns, err := dbc.GetEnsName(addressHex); err == nil {
+		result.AddressEns = &addressEns
+	}
+
 	res, err := json.Marshal(result)
 
 	if err != nil {

--- a/api/handlers.go
+++ b/api/handlers.go
@@ -1,6 +1,7 @@
 package webapi
 
 import (
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -646,7 +647,7 @@ func HandleChainInfo(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// HandleTxByAddress finds and returns a transaction by address (from or to)
+// HandleRichList returns addresses and its balances
 func HandleRichList(w http.ResponseWriter, r *http.Request) {
 	if r.Method != "GET" {
 		http.Error(w, "error", http.StatusBadRequest)
@@ -710,10 +711,88 @@ func HandleRichList(w http.ResponseWriter, r *http.Request) {
 
 // HandleAddReverseRegistrar inserts a new namehash -> name map
 func HandleAddReverseRegistrar(w http.ResponseWriter, r *http.Request) {
-	http.Error(w, "error", http.StatusNotImplemented)
+	if r.Method != "POST" {
+		http.Error(w, "error", http.StatusBadRequest)
+		return
+	}
+
+	dbc := db.GetClient()
+	if dbc == nil {
+		log.Printf("! Error: DBClient is not initialized!")
+		http.Error(w, "error", http.StatusInternalServerError)
+		return
+	}
+
+	decoder := json.NewDecoder(r.Body)
+	var ens models.ENS
+	err := decoder.Decode(&ens)
+	if err != nil {
+		log.Println("Error InsertEns failed", err.Error())
+		http.Error(w, "error", http.StatusBadRequest)
+		return
+	}
+
+	err = dbc.InsertEns(ens)
+	if err != nil {
+		log.Println("Error InsertEns failed", err.Error())
+		http.Error(w, "error", http.StatusBadRequest)
+		return
+	}
+
+	res, err := json.Marshal(ens)
+
+	if err != nil {
+		log.Printf("! Error: %s", err.Error())
+		http.Error(w, "error", http.StatusInternalServerError)
+	} else {
+		w.Write(res)
+	}
 }
 
 // HandleGetReverseRegistrar returns the address for a namehash
 func HandleGetReverseRegistrar(w http.ResponseWriter, r *http.Request) {
-	http.Error(w, "error", http.StatusNotImplemented)
+	if r.Method != "GET" {
+		http.Error(w, "error", http.StatusBadRequest)
+		return
+	}
+
+	dbc := db.GetClient()
+	if dbc == nil {
+		log.Printf("! Error: DBClient is not initialized!")
+		http.Error(w, "error", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+
+	vars := mux.Vars(r)
+	address, ok := vars["address"]
+	if !ok {
+		log.Printf("! Error: %s", errors.New("Parameter is address"))
+		http.Error(w, "error", http.StatusBadRequest)
+		return
+	}
+
+	name, err := dbc.GetEnsName(address)
+	if err != nil {
+		log.Printf("! Error: %s", err.Error())
+		if err == sql.ErrNoRows {
+			http.Error(w, http.StatusText(404), http.StatusNotFound)
+		} else {
+			http.Error(w, "error", http.StatusInternalServerError)
+		}
+		return
+	}
+
+	res := make(map[string]interface{})
+	res["name"] = name
+
+	out, err := json.Marshal(res)
+
+	if err != nil {
+		log.Printf("! Error: %s", err.Error())
+		http.Error(w, "error", http.StatusInternalServerError)
+	} else {
+		w.Write(out)
+	}
 }

--- a/api/handlers.go
+++ b/api/handlers.go
@@ -707,3 +707,13 @@ func HandleRichList(w http.ResponseWriter, r *http.Request) {
 		w.Write(res)
 	}
 }
+
+// HandleAddReverseRegistrar inserts a new namehash -> name map
+func HandleAddReverseRegistrar(w http.ResponseWriter, r *http.Request) {
+	http.Error(w, "error", http.StatusNotImplemented)
+}
+
+// HandleGetReverseRegistrar returns the address for a namehash
+func HandleGetReverseRegistrar(w http.ResponseWriter, r *http.Request) {
+	http.Error(w, "error", http.StatusNotImplemented)
+}

--- a/cmd/explorer/main.go
+++ b/cmd/explorer/main.go
@@ -105,7 +105,7 @@ func (ec explorerContext) startServer() cli.ActionFunc {
 		ec.router.HandleFunc("/rich-list", api.HandleRichList).Methods("GET")
 
 		ec.router.HandleFunc("/ens", api.HandleAddReverseRegistrar).Methods("POST")
-		ec.router.HandleFunc("/ens/{hash}", api.HandleGetReverseRegistrar).Methods("GET")
+		ec.router.HandleFunc("/ens/{address}", api.HandleGetReverseRegistrar).Methods("GET")
 
 		ec.router.HandleFunc("/delegates", api.HandleDelegates).Methods("GET")
 		ec.router.HandleFunc("/delegates/{number}", api.HandleDelegates).Methods("GET")

--- a/cmd/explorer/main.go
+++ b/cmd/explorer/main.go
@@ -104,6 +104,9 @@ func (ec explorerContext) startServer() cli.ActionFunc {
 
 		ec.router.HandleFunc("/rich-list", api.HandleRichList).Methods("GET")
 
+		ec.router.HandleFunc("/ens", api.HandleAddReverseRegistrar).Methods("POST")
+		ec.router.HandleFunc("/ens/{hash}", api.HandleGetReverseRegistrar).Methods("GET")
+
 		ec.router.HandleFunc("/delegates", api.HandleDelegates).Methods("GET")
 		ec.router.HandleFunc("/delegates/{number}", api.HandleDelegates).Methods("GET")
 

--- a/db/db.go
+++ b/db/db.go
@@ -150,7 +150,11 @@ func (cli *DBClient) GetLatestBlockNumber() (uint64, error) {
 
 // GetBlockByID finds and returns the block with the provided ID
 func (cli *DBClient) GetBlockByID(number uint64) (*models.Block, error) {
-	rows, err := cli.db.Query("SELECT * FROM blocks WHERE number = $1", number)
+	query := strings.Join([]string{
+		"SELECT b.*, ens.name FROM blocks AS b",
+		" LEFT JOIN ens ON ens.address = b.producer",
+		" WHERE b.number = $1"}, "")
+	rows, err := cli.db.Query(query, number)
 	if err != nil {
 		return nil, err
 	}
@@ -173,7 +177,8 @@ func (cli *DBClient) GetBlockByID(number uint64) (*models.Block, error) {
 		&block.GasLimit,
 		&delegatesRaw,
 		&producer,
-		&block.Signature)
+		&block.Signature,
+		&block.ProducerEns)
 	if err = rows.Err(); err != nil {
 		return nil, err
 	}
@@ -207,7 +212,10 @@ func (cli *DBClient) GetBlockByHash(hash string) (*models.Block, error) {
 	// Query for bytea value with the hex method, pass from char [1,end) since
 	// the required structure is E'\\xDEADBEEF'
 	// For more, check https://www.postgresql.org/docs/9.0/static/datatype-binary.html
-	query := strings.Join([]string{"SELECT * FROM blocks WHERE hash = E'\\\\", hash[1:], "'"}, "")
+	query := strings.Join([]string{
+		"SELECT b.*, ens.name FROM blocks AS b",
+		" LEFT JOIN ens ON ens.address = b.producer",
+		" WHERE b.hash = E'\\\\", hash[1:], "'"}, "")
 	rows, err := cli.db.Query(query)
 
 	if err != nil {
@@ -232,7 +240,8 @@ func (cli *DBClient) GetBlockByHash(hash string) (*models.Block, error) {
 		&block.GasLimit,
 		&delegatesRaw,
 		&producer,
-		&block.Signature)
+		&block.Signature,
+		&block.ProducerEns)
 	if err = rows.Err(); err != nil {
 		return nil, err
 	}
@@ -264,7 +273,12 @@ func (cli *DBClient) GetBlockByHash(hash string) (*models.Block, error) {
 
 // GetBlockByID finds and returns the block with the provided ID
 func (cli *DBClient) GetBlockRange(fromNumber, rng uint32) ([]models.Block, error) {
-	rows, err := cli.db.Query("SELECT * FROM blocks WHERE number <= $1 order by number desc limit $2", fromNumber, rng)
+	query := strings.Join([]string{
+		"SELECT b.*, ens.name FROM blocks AS b",
+		" LEFT JOIN ens ON ens.address = b.producer",
+		" WHERE b.number <= $1",
+		" ORDER BY b.number DESC LIMIT $2"}, "")
+	rows, err := cli.db.Query(query, fromNumber, rng)
 	if err != nil {
 		return nil, err
 	}
@@ -287,7 +301,8 @@ func (cli *DBClient) GetBlockRange(fromNumber, rng uint32) ([]models.Block, erro
 			&block.GasLimit,
 			&delegatesRaw,
 			&producer,
-			&block.Signature)
+			&block.Signature,
+			&block.ProducerEns)
 		if err = rows.Err(); err != nil {
 			return nil, err
 		}
@@ -320,22 +335,24 @@ func (cli *DBClient) GetBlocksByTimestamp(timestamp hexutil.Uint64, timestampCon
 	// Query for bytea value with the hex method, pass from char [1,end) since
 	// the required structure is E'\\xDEADBEEF'
 	// For more, check https://www.postgresql.org/docs/9.0/static/datatype-binary.html
-	query := "SELECT * FROM blocks"
+	query := strings.Join([]string{
+		"SELECT b.*, ens.name FROM blocks AS b",
+		" LEFT JOIN ens ON ens.address = b.producer"}, "")
 
 	switch timestampCondition {
 	case models.TIMESTAMP_EQUAL:
-		query = strings.Join([]string{query, " WHERE timestamp = $1"}, "")
+		query = strings.Join([]string{query, " WHERE b.timestamp = $1"}, "")
 	case models.TIMESTAMP_GREATER_EQUAL_THAN:
-		query = strings.Join([]string{query, " WHERE timestamp >= $1"}, "")
+		query = strings.Join([]string{query, " WHERE b.timestamp >= $1"}, "")
 	case models.TIMESTAMP_SMALLER_EQUAL_THAN:
-		query = strings.Join([]string{query, " WHERE timestamp <= $1"}, "")
+		query = strings.Join([]string{query, " WHERE b.timestamp <= $1"}, "")
 	}
 
 	if common.IsHexAddress(producer) {
-		query = strings.Join([]string{query, " AND producer = E'\\\\", producer[1:], "'"}, "")
+		query = strings.Join([]string{query, " AND b.producer = E'\\\\", producer[1:], "'"}, "")
 	}
 
-	query = strings.Join([]string{query, " ORDER BY timestamp DESC"}, "")
+	query = strings.Join([]string{query, " ORDER BY b.timestamp DESC"}, "")
 
 	rows, err := cli.db.Query(query, timestamp)
 	if err != nil {
@@ -360,7 +377,8 @@ func (cli *DBClient) GetBlocksByTimestamp(timestamp hexutil.Uint64, timestampCon
 			&block.GasLimit,
 			&delegatesRaw,
 			&producer,
-			&block.Signature)
+			&block.Signature,
+			&block.ProducerEns)
 		if err = rows.Err(); err != nil {
 			return nil, err
 		}
@@ -393,7 +411,12 @@ func (cli *DBClient) GetTransactionByHash(hash string) (*models.TransactionFull,
 	// Query for bytea value with the hex method, pass from char [1,end) since
 	// the required structure is E'\\xDEADBEEF'
 	// For more, check https://www.postgresql.org/docs/9.0/static/datatype-binary.html
-	query := strings.Join([]string{"SELECT * FROM transactions WHERE hash = E'\\\\", hash[1:], "'"}, "")
+	query := strings.Join([]string{
+		"SELECT t.*, ensf.name, enst.name, ensc.name FROM transactions AS t",
+		" LEFT JOIN ens AS ensf ON ensf.address = t.addr_from",
+		" LEFT JOIN ens AS enst ON enst.address = t.addr_to",
+		" LEFT JOIN ens AS ensc ON ensc.address = t.contract_address",
+		" WHERE t.hash = E'\\\\", hash[1:], "'"}, "")
 	rows, err := cli.db.Query(query)
 
 	if err != nil {
@@ -427,7 +450,10 @@ func (cli *DBClient) GetTransactionByHash(hash string) (*models.TransactionFull,
 		&input,
 		&txr.Status,
 		&tx.WorkNonce,
-		&tx.Timestamp)
+		&tx.Timestamp,
+		&tx.FromEns,
+		&tx.ToEns,
+		&txr.ContractAddressEns)
 	if err = rows.Err(); err != nil {
 		return nil, err
 	}
@@ -528,25 +554,36 @@ func (cli *DBClient) GetTransactionsByAddress(address string, addrtype models.Ad
 	// Query for bytea value with the hex method, pass from char [1,end) since
 	// the required structure is E'\\xDEADBEEF'
 	// For more, check https://www.postgresql.org/docs/9.0/static/datatype-binary.html
-	query := "SELECT * FROM transactions"
+	query := strings.Join([]string{
+		"SELECT t.*, ensf.name, enst.name, ensc.name FROM transactions AS t",
+		" LEFT JOIN ens AS ensf ON ensf.address = t.addr_from",
+		" LEFT JOIN ens AS enst ON enst.address = t.addr_to",
+		" LEFT JOIN ens AS ensc ON ensc.address = t.contract_address"}, "")
 
 	switch addrtype {
 	case models.ADDRESS_TO:
-		query = strings.Join([]string{query, " WHERE addr_to = E'\\\\", address[1:], "'"}, "")
+		query = strings.Join([]string{query, " WHERE t.addr_to = E'\\\\", address[1:], "'"}, "")
 	case models.ADDRESS_FROM:
-		query = strings.Join([]string{query, " WHERE addr_from = E'\\\\", address[1:], "'"}, "")
+		query = strings.Join([]string{query, " WHERE t.addr_from = E'\\\\", address[1:], "'"}, "")
 	case models.ADDRESS_ALL:
-		query = strings.Join([]string{query, " WHERE addr_to = E'\\\\", address[1:], "'", " or addr_from = E'\\\\", address[1:], "'"}, "")
+		query = strings.Join([]string{query, " WHERE t.addr_to = E'\\\\", address[1:], "'", " or t.addr_from = E'\\\\", address[1:], "'"}, "")
 	case models.ADDRESS_BLOCKHASH:
-		query = strings.Join([]string{"SELECT transactions.* FROM transactions, blocks WHERE blocks.number =  transactions.block_number AND blocks.hash = E'\\\\", address[1:], "'"}, "")
+		query = strings.Join([]string{
+			"SELECT t.*, ensf.name, enst.name, ensc.name",
+			" FROM transactions AS t",
+			" INNER JOIN blocks AS b ON b.number = t.block_number",
+			" LEFT JOIN ens AS ensf ON ensf.address = t.addr_from",
+			" LEFT JOIN ens AS enst ON enst.address = t.addr_to",
+			" LEFT JOIN ens AS ensc ON ensc.address = t.contract_address",
+			" WHERE b.hash = E'\\\\", address[1:], "'"}, "")
 	}
 
 	if order != "asc" {
 		switch addrtype {
 		case models.LATEST:
-			query = strings.Join([]string{query, " ORDER BY block_number ", order}, "")
+			query = strings.Join([]string{query, " ORDER BY t.block_number ", order}, "")
 		default:
-			query = strings.Join([]string{query, " ORDER BY timestamp ", order}, "")
+			query = strings.Join([]string{query, " ORDER BY t.timestamp ", order}, "")
 		}
 	}
 
@@ -586,7 +623,10 @@ func (cli *DBClient) GetTransactionsByAddress(address string, addrtype models.Ad
 			&input,
 			&txr.Status,
 			&tx.WorkNonce,
-			&tx.Timestamp)
+			&tx.Timestamp,
+			&tx.FromEns,
+			&tx.ToEns,
+			&txr.ContractAddressEns)
 		if err = rows.Err(); err != nil {
 			log.Println(err)
 			return nil, err
@@ -794,7 +834,7 @@ func (cli *DBClient) InsertBalance(address common.Address, balance uint64, block
 	sql := `
 		INSERT INTO balances(address, amount, block_number) VALUES (E'\\x%s', %d, %d)
 		ON CONFLICT (address) DO UPDATE
-  			SET amount = excluded.amount, block_number = excluded.block_number
+			SET amount = excluded.amount, block_number = excluded.block_number
 	`
 	adr := common.Bytes2Hex(address[:])[:]
 	//	log.Println(fmt.Sprintf(sql, adr, balance, blockNumber))
@@ -818,8 +858,11 @@ func (cli *DBClient) GetBalanceStats() (uint64, uint64, uint64, error) {
 
 // GetTopBalances gets the rich list
 func (cli *DBClient) GetTopBalances(limit uint64, offset uint64) ([]models.Balance, error) {
-
-	query := "SELECT address, amount, block_number FROM balances ORDER BY amount DESC LIMIT $1 OFFSET $2"
+	query := strings.Join([]string{
+		"SELECT b.address, b.amount, b.block_number, ens.name",
+		" FROM balances AS b",
+		" LEFT JOIN ens ON ens.address = b.address",
+		" ORDER BY b.amount DESC LIMIT $1 OFFSET $2"}, "")
 	rows, err := cli.db.Query(query, limit, offset)
 
 	if err != nil {
@@ -831,10 +874,11 @@ func (cli *DBClient) GetTopBalances(limit uint64, offset uint64) ([]models.Balan
 
 	for rows.Next() {
 		var addressBytes []byte
+		var addressEns string
 		var amount uint64
 		var blockNumber uint64
 
-		rows.Scan(&addressBytes, &amount, &blockNumber)
+		rows.Scan(&addressBytes, &amount, &blockNumber, &addressEns)
 		if err = rows.Err(); err != nil {
 			log.Println(err)
 			return nil, err
@@ -842,7 +886,7 @@ func (cli *DBClient) GetTopBalances(limit uint64, offset uint64) ([]models.Balan
 
 		address := common.BytesToAddress(addressBytes)
 
-		result = append(result, models.Balance{Address: address, Amount: amount, BlockNumber: blockNumber})
+		result = append(result, models.Balance{Address: address, AddressEns: addressEns, Amount: amount, BlockNumber: blockNumber})
 	}
 
 	return result, nil

--- a/models/models.go
+++ b/models/models.go
@@ -29,6 +29,7 @@ type Block struct {
 	Transactions     []common.Hash    `json:"transactions"`
 	Delegates        []common.Address `json:"delegates"`
 	Producer         common.Address   `json:"producer"`
+	ProducerEns      *string          `json:"producerEns"`
 }
 
 type JSONBlock Block
@@ -51,6 +52,7 @@ func (b Block) MarshalJSON() ([]byte, error) {
 		GasLimit         uint64           `json:"gasLimit"`
 		Delegates        []common.Address `json:"delegates"`
 		Producer         common.Address   `json:"producer"`
+		ProducerEns      *string          `json:"producerEns"`
 	}
 
 	enc.Number = uint64(b.Number)
@@ -66,6 +68,7 @@ func (b Block) MarshalJSON() ([]byte, error) {
 	enc.GasLimit = uint64(b.GasLimit)
 	enc.Delegates = b.Delegates
 	enc.Producer = b.Producer
+	enc.ProducerEns = b.ProducerEns
 
 	return json.Marshal(&enc)
 }
@@ -80,7 +83,9 @@ type Transaction struct {
 	BlockNumber      hexutil.Uint64  `json:"blockNumber"`
 	TransactionIndex hexutil.Uint64  `json:"transactionIndex"`
 	From             common.Address  `json:"from"`
+	FromEns          *string         `json:"fromEns"`
 	To               *common.Address `json:"to"`
+	ToEns            *string         `json:"toEns"`
 	Value            hexutil.Big     `json:"value"`
 	GasLimit         hexutil.Uint64  `json:"gas"`
 	GasPrice         hexutil.Uint64  `json:"gasPrice"`
@@ -89,10 +94,11 @@ type Transaction struct {
 }
 
 type TransactionReceipt struct {
-	Status            hexutil.Uint64  `json:"status"`
-	GasUsed           hexutil.Uint64  `json:"gasUsed"`
-	CumulativeGasUsed hexutil.Uint64  `json:"cumulativeGasUsed"`
-	ContractAddress   *common.Address `json:"contractAddress"`
+	Status             hexutil.Uint64  `json:"status"`
+	GasUsed            hexutil.Uint64  `json:"gasUsed"`
+	CumulativeGasUsed  hexutil.Uint64  `json:"cumulativeGasUsed"`
+	ContractAddress    *common.Address `json:"contractAddress"`
+	ContractAddressEns *string         `json:"contractAddressEns"`
 }
 
 type TransactionFull struct {
@@ -180,23 +186,26 @@ func (t *InputData) UnmarshalJSON(b []byte) error {
 func (tf TransactionFull) MarshalJSON() ([]byte, error) {
 	// Struct with only the fields we want in the final JSON?
 	var enc struct {
-		Hash              common.Hash     `json:"hash"`
-		Timestamp         uint64          `json:"timestamp"`
-		Status            uint64          `json:"status"`
-		Nonce             uint64          `json:"nonce"`
-		BlockHash         common.Hash     `json:"blockHash"`
-		BlockNumber       uint64          `json:"blockNumber"`
-		TransactionIndex  uint64          `json:"transactionIndex"`
-		From              common.Address  `json:"from"`
-		To                *common.Address `json:"to"`
-		Value             *big.Int        `json:"value"`
-		GasUsed           uint64          `json:"gasUsed"`
-		CumulativeGasUsed uint64          `json:"cumulativeGasUsed"`
-		GasLimit          uint64          `json:"gasLimit"`
-		GasPrice          uint64          `json:"gasPrice"`
-		WorkNonce         uint64          `json:"workNonce"`
-		ContractAddress   *common.Address `json:"contractAddress"`
-		Input             string          `json:"input"`
+		Hash               common.Hash     `json:"hash"`
+		Timestamp          uint64          `json:"timestamp"`
+		Status             uint64          `json:"status"`
+		Nonce              uint64          `json:"nonce"`
+		BlockHash          common.Hash     `json:"blockHash"`
+		BlockNumber        uint64          `json:"blockNumber"`
+		TransactionIndex   uint64          `json:"transactionIndex"`
+		From               common.Address  `json:"from"`
+		FromEns            *string         `json:"fromEns"`
+		To                 *common.Address `json:"to"`
+		ToEns              *string         `json:"toEns"`
+		Value              *big.Int        `json:"value"`
+		GasUsed            uint64          `json:"gasUsed"`
+		CumulativeGasUsed  uint64          `json:"cumulativeGasUsed"`
+		GasLimit           uint64          `json:"gasLimit"`
+		GasPrice           uint64          `json:"gasPrice"`
+		WorkNonce          uint64          `json:"workNonce"`
+		ContractAddress    *common.Address `json:"contractAddress"`
+		ContractAddressEns *string         `json:"contractAddressEns"`
+		Input              string          `json:"input"`
 	}
 
 	t := tf.Tx
@@ -210,7 +219,9 @@ func (tf TransactionFull) MarshalJSON() ([]byte, error) {
 	enc.BlockNumber = uint64(t.BlockNumber)
 	enc.TransactionIndex = uint64(t.TransactionIndex)
 	enc.From = t.From
+	enc.FromEns = t.FromEns
 	enc.To = t.To
+	enc.ToEns = t.ToEns
 	enc.Value = t.Value.ToInt()
 	enc.GasUsed = uint64(r.GasUsed)
 	enc.CumulativeGasUsed = uint64(r.CumulativeGasUsed)
@@ -218,6 +229,7 @@ func (tf TransactionFull) MarshalJSON() ([]byte, error) {
 	enc.GasPrice = uint64(t.GasPrice)
 	enc.WorkNonce = uint64(t.WorkNonce)
 	enc.ContractAddress = r.ContractAddress
+	enc.ContractAddressEns = r.ContractAddressEns
 	enc.Input = "0x" + hex.EncodeToString(t.Input)
 
 	return json.Marshal(&enc)
@@ -225,6 +237,7 @@ func (tf TransactionFull) MarshalJSON() ([]byte, error) {
 
 type AddressResult struct {
 	Address      common.Address `json:"address"`
+	AddressEns   *string        `json:"addressEns"`
 	Balance      *big.Int       `json:"balance"`
 	Stake        uint64         `json:"stake"`
 	TxCount      uint64         `json:"tx_count"`
@@ -247,12 +260,13 @@ type DelegateVoteInfo struct {
 
 type Balance struct {
 	Address     common.Address `json:"address"`
+	AddressEns  string         `json:"addressEns"`
 	Amount      uint64         `json:"amount"`
 	BlockNumber uint64         `json:"block_number"`
 }
 
 func (b Balance) MarshalJSON() ([]byte, error) {
-	return []byte(fmt.Sprintf(`{"address":"0x%s","amount":%.4f}`, common.Bytes2Hex(b.Address[:]), float32(b.Amount)/10000.0)), nil
+	return []byte(fmt.Sprintf(`{"address":"0x%s","addressEns":"%s","amount":%.4f}`, common.Bytes2Hex(b.Address[:]), b.AddressEns, float32(b.Amount)/10000.0)), nil
 }
 
 type ENS struct {

--- a/models/models.go
+++ b/models/models.go
@@ -254,3 +254,13 @@ type Balance struct {
 func (b Balance) MarshalJSON() ([]byte, error) {
 	return []byte(fmt.Sprintf(`{"address":"0x%s","amount":%.4f}`, common.Bytes2Hex(b.Address[:]), float32(b.Amount)/10000.0)), nil
 }
+
+type ENS struct {
+	Address common.Address `json:"address"`
+	Hash    common.Hash    `json:"hash"`
+	Name    string         `json:"name"`
+}
+
+func (e ENS) MarshalJSON() ([]byte, error) {
+	return []byte(fmt.Sprintf(`{"address":"0x%s","hash":"0x%s","name":"%s"}`, common.Bytes2Hex(e.Address[:]), common.Bytes2Hex(e.Hash[:]), e.Name)), nil
+}

--- a/schema/create.sql
+++ b/schema/create.sql
@@ -51,6 +51,14 @@ CREATE TABLE balances (
 
 CREATE INDEX bl_amount_idx ON balances USING btree (amount);
 
+CREATE TABLE ens (
+  address bytea PRIMARY KEY,
+  hash bytea,
+  name VARCHAR(64)
+);
+
+CREATE INDEX ens_name_idx ON ens USING btree (name);
+
 CREATE TABLE globals (
   var_name CHAR(64) PRIMARY KEY,
   value_int BIGINT,


### PR DESCRIPTION
The ENS contract doesn't store the actual string name mapped to an address, which makes impossible to ask the address for a name. For this reason, the API will be able to list known ENS names.